### PR TITLE
Updated terms & privacy policy

### DIFF
--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -1,9 +1,14 @@
 <footer class="footer">
   <div class="container container-fluid text-muted">
-      <p>Licensing information for the Molecular Oncology Almanac Portal is available on <a href="{{ CONFIG['METHOD']['GIT_REPO'] }}" target="_blank">Github</a>.</p>
-      <p>DIAGNOSTIC AND CLINICAL USE PROHIBITED.  THE BROAD INSTITUTE and DFCI MAKE NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT OR VALIDITY OF ANY INTELLECTUAL PROPERTY RIGHTS OR CLAIMS, WHETHER ISSUED OR PENDING, AND THE ABSENCE OF LATENT OR OTHER DEFECTS, WHETHER OR NOT DISCOVERABLE.</p>
-      <p>In no event shall Broad or DFCI or their Trustees, Directors, Officers, Employees, Students, Affiliates, Core Faculty, Associate Faculty and Contractors, be liable for incidental, punitive, consequential or special damages, including economic damages or injury to persons or property or lost profits, regardless of whether the party was advised, had other reason to know or in fact knew of the possibility of the foregoing, regardless of fault, and regardless of legal theory or basis. You may not download or use any portion of this program for any use not expressly authorized by the Broad. You further agree that the program shall not be used as the basis of a commercial product and that the program shall not be rewritten or otherwise adapted to circumvent the need for obtaining permission for use of the program other than as specified herein.</p>
-      <ul id="logo-list" class="list-inline">
+      <p align="center">
+          Please review our <a href="{{ url_for('privacy') }}">privacy policy</a> and <a href="{{ url_for('terms') }}">terms</a> before use.
+          <br>
+          <a href = "mailto: moalmanac@ds.dfci.harvard.edu" target="_blank">Contact</a> |
+          <a href="https://github.com/topics/molecular-oncology-almanac" target="_blank">Github</a> |
+          <a href="https://twitter.com/moalmanac" target="_blank">Twitter</a>
+      </p>
+      <br>
+      <ul id="logo-list" class="list-inline" align="center">
         <li><a href="http://www.broadinstitute.org/" target="_blank">
             <img src="{{ url_for('static', filename = 'img/broad.png') }}" class="img-responsive" height=50>
         </a></li>

--- a/app/templates/navbar.html
+++ b/app/templates/navbar.html
@@ -25,10 +25,10 @@
                         <li><a href="{{ CONFIG['METHOD']['GIT_REPO'] }}/issues" target="_blank">
                             <span class="glyphicon glyphicon-exclamation-sign"></span>&nbsp;&nbsp;Issues</a>
                         </li>
-                        <li><a href="{{ url_for('privacy') }}" target="_blank">
+                        <li><a href="{{ url_for('privacy') }}">
                             <span class="glyphicon glyphicon-lock"></span>&nbsp;&nbsp;Privacy Policy</a>
                         </li>
-                        <li><a href="{{ url_for('terms') }}" target="_blank">
+                        <li><a href="{{ url_for('terms') }}">
                             <span class="glyphicon glyphicon-file"></span>&nbsp;&nbsp;Terms of Use</a>
                         </li>
                     </ul>

--- a/app/templates/privacy.html
+++ b/app/templates/privacy.html
@@ -1,94 +1,14 @@
 {% extends 'base.html' %}
 
-{% block title %} Privacy Policy {% endblock %}
+{% block title %} Molecular Oncology Almanac Portal: Privacy Policy {% endblock %}
 
 {% block page_content %}
-
-	<div class="container">
-        <div class="row">
-            <h2 class="text-left">Privacy Policy</h2>
-            <p class="text-left">
-                <strong>Effective Date: December 29, 2020</strong>
-                <br><br>
-                The Van Allen laboratory at Dana-farber Cancer Institute and the Broad Institute of MIT & Harvard ("us", "we", or "our") operates the Molecular Oncology Almanac portal (<a href="{{ url_for('index') }}">https://portal.moalmanac.org</a>) (hereinafter referred to as the "Service"). The Service is used to create a Terra workspace on the user's behalf under the specified billing project, upload provided inputs, and launch the <a href="https://github.com/vanallenlab/moalmanac">Molecular Oncology Almanac</a> clinical interpretation algorithm for precision oncology on behalf of the user.
-                <br><br>
-                This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service and the choices you have associated with that data. The Privacy Policy for the Service is based on the <a href="https://termsfeed.com/blog/sample-privacy-policy-template/">TermsFeed's Privacy Policy Template</a>.
-                <br><br>
-                We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy.
-
-                <h4>Definitions</h4>
-                <ul>
-                    <li><strong>Personal Data</strong>, any type of data that can be used to directly or indirectly identify an individual.</li>
-                </ul>
-
-                <h4>Information Collection and Use</h4>
-                <h5>Personal Data</h5>
-                While using our Service, we may ask you to provide certain Personal Data to us. We collect this data to for authorization of the user, to execute the Service, and to reach out to users for feedback on our Service. Personal Data may include, but is not limited to:
-                <ul>
-                    <li>Email address, which is collected upon logging into this webpage.</li>
-                </ul>
-                <h5>Google Cloud scopes</h5>
-                When using our Service, certain scopes are requested on the user's behalf from Google to operate the Service. Specifically,
-                <ul>
-                    <li>https://www.googleapis.com/auth/cloud-platform, to upload inputs to your workspace's bucket</li>
-                    <li>https://www.googleapis.com/auth/userinfo.email, to obtain your email address</li>
-                </ul>
-
-                <strong>We will not have access to any input files uploaded to the Terra workspace created on your behalf through this Service.</strong>
-
-                <h4>Use of Data</h4>
-                Molecular Oncology Almanac uses the collected data for various purposes:
-                <ul>
-                    <li>To provide and maintain the Service</li>
-                    <li>To collect user feedback about the Service</li>
-                    <li>To notify you about changes to our Service</li>
-                    <li>To provide user care and support</li>
-                    <li>To provide analysis or valuable information so that we can improve the Service</li>
-                    <li>To monitor the usage of the Service</li>
-                    <li>To detect, prevent and address technical issues</li>
-                </ul>
-
-                <h4>Transfer of Data</h4>
-                Your information, including Personal Data, may be transferred to - and maintained on - computers located in the United States of America which may be located outside of your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from your jurisdiction.
-                <br><br>
-                By submitting your information, including Personal Data, as part of the Service, you consent to abide and be bound by this Privacy Policy.
-                <br><br>
-                Molecular Oncology Almanac Portal will take all steps reasonably necessary in accordance with United States law to ensure that your data is treated securely and in accordance with this Privacy Policy.
-
-                <h4>Disclosure of Data</h4>
-                Molecular Oncology Almanac may disclose your Personal Data in the good faith belief that such action is necessary to:
-                <ul>
-                    <li>To comply with a legal obligation</li>
-                    <li>To protect and defend the rights or property of Molecular Oncology Almanac</li>
-                    <li>To prevent or investigate possible wrongdoing in connection with the Service</li>
-                    <li>To protect the personal safety of users of the Service or the public</li>
-                    <li>To protect against legal liability</li>
-                </ul>
-
-                <h4>Security of Data</h4>
-                The security of your data is important to us but remember that no method of transmission over the Internet or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your Personal Data, we cannot guarantee its absolute security.
-
-                <h4>Service Providers</h4>
-                We may employ third party companies and individuals to facilitate our Service ("Service Providers"), to provide the Service on our behalf, to perform Service-related services or to assist us in analyzing how our Service is used.
-                <br><br>
-                These third parties have access to your Personal Data only to perform these tasks on our behalf and are obligated not to disclose or use it for any other purpose.
-
-                <h4>Links to Other Sites</h4>
-                Our Service may contain links to other sites that are not operated by us. If you click a third party link, you will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you visit.
-                <br><br>
-                We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.
-
-                <h4>Changes to this Privacy Policy</h4>
-                We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.  Your continued use of the Service after we post any modifications to this Privacy Policy will constitute your acknowledgment of the modifications and your consent to abide and be bound by the modified Privacy Policy.
-                <br><br>
-                We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and update the "effective date" at the top of this Privacy Policy.
-                <br><br>
-                You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
-
-                <h4>Contact us</h4>
-                If you have any questions about this Privacy Policy, please contact us at vanallenlab [at] ds.dfci.harvard.edu or through Github.
-            </p>
-        </div>
-	</div>
-
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title"><strong>Privacy policy</strong></h3>
+    </div>
+    <div class="panel-body">
+        {% include "privacy_content.html" %}
+    </div>
+</div>
 {% endblock %}

--- a/app/templates/privacy_content.html
+++ b/app/templates/privacy_content.html
@@ -1,0 +1,106 @@
+<p>
+    <strong>
+        Effective date: April 29, 2021
+    </strong>
+</p>
+
+<p>
+    The Van Allen laboratory at Dana-farber Cancer Institute and the Broad Institute of MIT & Harvard ("us", "we", or "our") operates the Molecular Oncology Almanac portal (<a href="{{ url_for('index') }}">https://portal.moalmanac.org</a>) (hereinafter referred to as the "Service"). The Service is used to create a Terra workspace on the user's behalf under the specified billing project, upload provided inputs, and launch the <a href="https://github.com/vanallenlab/moalmanac">Molecular Oncology Almanac</a> clinical interpretation algorithm for precision oncology on behalf of the user.
+    <br><br>
+    This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service and the choices you have associated with that data. The Privacy Policy for the Service is based on the <a href="https://termsfeed.com/blog/sample-privacy-policy-template/">TermsFeed's Privacy Policy Template</a>.
+    <br><br>
+    We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy.
+</p>
+
+<h3>Definitions</h3>
+<p>
+    <ul>
+        <li><strong>Personal Data</strong>, any type of data that can be used to directly or indirectly identify an individual.</li>
+    </ul>
+</p>
+
+<h3>Information Collection and Use</h3>
+<p>
+    <h4>Personal Data</h4>
+    While using our Service, we may ask you to provide certain Personal Data to us. We collect this data to for authorization of the user, to execute the Service, and to reach out to users for feedback on our Service. Personal Data may include, but is not limited to:
+    <ul>
+        <li>Email address, which is collected upon logging into this webpage.</li>
+    </ul>
+
+    <h4>Google Cloud scopes</h4>
+    When using our Service, certain scopes are requested on the user's behalf from Google to operate the Service. Specifically,
+    <ul>
+        <li>https://www.googleapis.com/auth/cloud-platform, to upload inputs to your workspace's bucket</li>
+        <li>https://www.googleapis.com/auth/userinfo.email, to obtain your email address</li>
+    </ul>
+
+    <strong>We will not have access to any input files uploaded to the Terra workspace created on your behalf through this Service.</strong>
+</p>
+
+<h3>Use of Data</h3>
+<p>
+    Molecular Oncology Almanac uses the collected data for various purposes:
+    <ul>
+        <li>To provide and maintain the Service</li>
+        <li>To collect user feedback about the Service</li>
+        <li>To notify you about changes to our Service</li>
+        <li>To provide user care and support</li>
+        <li>To provide analysis or valuable information so that we can improve the Service</li>
+        <li>To monitor the usage of the Service</li>
+        <li>To detect, prevent and address technical issues</li>
+    </ul>
+</p>
+
+<h3>Transfer of Data</h3>
+<p>
+    Your information, including Personal Data, may be transferred to - and maintained on - computers located in the United States of America which may be located outside of your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from your jurisdiction.
+    <br><br>
+    By submitting your information, including Personal Data, as part of the Service, you consent to abide and be bound by this Privacy Policy.
+    <br><br>
+    Molecular Oncology Almanac Portal will take all steps reasonably necessary in accordance with United States law to ensure that your data is treated securely and in accordance with this Privacy Policy.
+</p>
+
+<h3>Disclosure of Data</h3>
+<p>
+    Molecular Oncology Almanac may disclose your Personal Data in the good faith belief that such action is necessary to:
+    <ul>
+        <li>To comply with a legal obligation</li>
+        <li>To protect and defend the rights or property of Molecular Oncology Almanac</li>
+        <li>To prevent or investigate possible wrongdoing in connection with the Service</li>
+        <li>To protect the personal safety of users of the Service or the public</li>
+        <li>To protect against legal liability</li>
+    </ul>
+</p>
+
+<h3>Security of Data</h3>
+<p>
+    The security of your data is important to us but remember that no method of transmission over the Internet or method of electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your Personal Data, we cannot guarantee its absolute security.
+</p>
+
+<h3>Service Providers</h3>
+<p>
+    We may employ third party companies and individuals to facilitate our Service ("Service Providers"), to provide the Service on our behalf, to perform Service-related services or to assist us in analyzing how our Service is used.
+    <br><br>
+    These third parties have access to your Personal Data only to perform these tasks on our behalf and are obligated not to disclose or use it for any other purpose.
+</p>
+
+<h3>Links to Other Sites</h3>
+<p>
+    Our Service may contain links to other sites that are not operated by us. If you click a third party link, you will be directed to that third party's site. We strongly advise you to review the Privacy Policy of every site you visit.
+    <br><br>
+    We have no control over and assume no responsibility for the content, privacy policies or practices of any third party sites or services.
+</p>
+
+<h3>Changes to this Privacy Policy</h3>
+<p>
+    We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy on this page.  Your continued use of the Service after we post any modifications to this Privacy Policy will constitute your acknowledgment of the modifications and your consent to abide and be bound by the modified Privacy Policy.
+    <br><br>
+    We will let you know via email and/or a prominent notice on our Service, prior to the change becoming effective and update the "effective date" at the top of this Privacy Policy.
+    <br><br>
+    You are advised to review this Privacy Policy periodically for any changes. Changes to this Privacy Policy are effective when they are posted on this page.
+</p>
+
+<h3>Contact us</h3>
+<p>
+    If you have any questions about this Privacy Policy, please contact us at moalmanac [at] ds.dfci.harvard.edu.
+</p>

--- a/app/templates/terms.html
+++ b/app/templates/terms.html
@@ -1,29 +1,14 @@
 {% extends 'base.html' %}
 
-{% block title %} Terms of Use {% endblock %}
+{% block title %} Molecular Oncology Almanac Portal: Terms of Use {% endblock %}
 
 {% block page_content %}
-
-	<div class="container">
-        <div class="row">
-            <h2 class="text-left">Terms of Use ("Terms")</h2>
-            <p class="text-left">
-                <strong>Last updated 29 December 2020</strong>
-                <br><br>
-                Please read these Terms of Use ("Terms", "Terms of Use") carefully before using the <a href="{{ url_for('index') }}">https://portal.moalmanac.org</a> website and to launch the Molecular Oncology Almanac (the "Service"), operated by the Van Allen laboratory at Dana-Farber Cancer Institute and the Broad Institute of MIT & Harvard ("us", "we", or "our"), on <a href="https://terra.bio">Terra</a>. The Service is used to launch the Molecular Oncology Almanac on Terra on the user's behalf. We may periodically update the content of this webpage and associated Terra method.
-                <br><br>
-                Your access to and use of the Service is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all visitors, users and others who access or use the Service.
-                <br><br>
-                <strong>By accessing or using the Service you agree to be bound by these Terms. If you disagree with any part of the terms then you may not access the Service.</strong>
-                <br><br>
-                <h4>For Research Use Only</h4>
-                <p>DIAGNOSTIC AND CLINICAL USE PROHIBITED.  THE BROAD INSTITUTE and DFCI MAKE NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT OR VALIDITY OF ANY INTELLECTUAL PROPERTY RIGHTS OR CLAIMS, WHETHER ISSUED OR PENDING, AND THE ABSENCE OF LATENT OR OTHER DEFECTS, WHETHER OR NOT DISCOVERABLE.</p>
-                <p>In no event shall Broad or DFCI or their Trustees, Directors, Officers, Employees, Students, Affiliates, Core Faculty, Associate Faculty and Contractors, be liable for incidental, punitive, consequential or special damages, including economic damages or injury to persons or property or lost profits, regardless of whether the party was advised, had other reason to know or in fact knew of the possibility of the foregoing, regardless of fault, and regardless of legal theory or basis. You may not download or use any portion of this program for any use not expressly authorized by the Broad. You further agree that the program shall not be used as the basis of a commercial product and that the program shall not be rewritten or otherwise adapted to circumvent the need for obtaining permission for use of the program other than as specified herein.</p>
-
-                <h4>Contact us</h4>
-                If you have any questions about these Terms, please contact us at vanallenlab [at] ds.dfci.harvard.edu or through Github.
-            </p>
-        </div>
-	</div>
-
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title"><strong>Terms of Use ("Terms")</strong></h3>
+    </div>
+    <div class="panel-body">
+        {% include "terms_content.html" %}
+    </div>
+</div>
 {% endblock %}

--- a/app/templates/terms_content.html
+++ b/app/templates/terms_content.html
@@ -1,0 +1,18 @@
+<p>
+    <strong>
+        Last updated April 29, 2021
+    </strong>
+    <br><br>
+    Please read these Terms of Use ("Terms", "Terms of Use") carefully before using the <a href="{{ url_for('index') }}">https://portal.moalmanac.org</a> website and to launch the Molecular Oncology Almanac (the "Service"), operated by the Van Allen laboratory at Dana-Farber Cancer Institute and the Broad Institute of MIT & Harvard ("us", "we", or "our"), on <a href="https://terra.bio">Terra</a>. The Service is used to launch the Molecular Oncology Almanac on Terra on the user's behalf. We may periodically update the content of this webpage and associated Terra method.
+    <br><br>
+    Your access to and use of the Service is conditioned on your acceptance of and compliance with these Terms. These Terms apply to all visitors, users and others who access or use the Service.
+    <br><br>
+    <strong>By accessing or using the Service you agree to be bound by these Terms. If you disagree with any part of the terms then you may not access the Service.</strong>
+
+    <h3>For Research Use Only</h3>
+    <p>DIAGNOSTIC AND CLINICAL USE PROHIBITED.  THE BROAD INSTITUTE and DFCI MAKE NO REPRESENTATIONS OR WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT OR VALIDITY OF ANY INTELLECTUAL PROPERTY RIGHTS OR CLAIMS, WHETHER ISSUED OR PENDING, AND THE ABSENCE OF LATENT OR OTHER DEFECTS, WHETHER OR NOT DISCOVERABLE.</p>
+    <p>In no event shall Broad or DFCI or their Trustees, Directors, Officers, Employees, Students, Affiliates, Core Faculty, Associate Faculty and Contractors, be liable for incidental, punitive, consequential or special damages, including economic damages or injury to persons or property or lost profits, regardless of whether the party was advised, had other reason to know or in fact knew of the possibility of the foregoing, regardless of fault, and regardless of legal theory or basis. You may not download or use any portion of this program for any use not expressly authorized by the Broad. You further agree that the program shall not be used as the basis of a commercial product and that the program shall not be rewritten or otherwise adapted to circumvent the need for obtaining permission for use of the program other than as specified herein.</p>
+
+    <h3>Contact us</h3>
+    If you have any questions about these Terms, please contact us at moalmanac [at] ds.dfci.harvard.edu.
+</p>


### PR DESCRIPTION
We updated how the terms and privacy policy are displayed on the web page and also updated the contact email address. Some minor UI changes were made, updating the footer and the navbar to not open a new window for the terms and privacy policy.